### PR TITLE
Added support for empty tags in getOuterHTML

### DIFF
--- a/index.js
+++ b/index.js
@@ -237,10 +237,10 @@ DomUtils.getOuterHTML = function(elem){
 		}
 	}
 
-	if (!emptyTags[elem.name]) {
-		return ret + ">" + DomUtils.getInnerHTML(elem) + "</" + elem.name + ">";
-	} else {
+	if (emptyTags[elem.name] && elem.children.length === 0) {
 		return ret + "/>";
+	} else {
+		return ret + ">" + DomUtils.getInnerHTML(elem) + "</" + elem.name + ">";
 	}
 };
 


### PR DESCRIPTION
This fixes an issue where empty tags, such as "<br />", were being output with a closing tag, e.g. "<br></br>", which was being interpreted by some browsers (in particular, Chrome) as two separate elements.
