### PR TITLE
Implement `removeSubsets` method

### DIFF
--- a/index.js
+++ b/index.js
@@ -276,3 +276,5 @@ DomUtils.prepend = function(elem, prev){
 	prev.next = elem;
 	elem.prev = prev;
 };
+
+DomUtils.removeSubsets = require('./lib/remove-subsets');

--- a/lib/remove-subsets.js
+++ b/lib/remove-subsets.js
@@ -1,0 +1,30 @@
+// removeSubsets
+// Given an array of nodes, remove any member that is contained by another.
+module.exports = function(nodes) {
+	var idx = nodes.length, node, ancestor, replace;
+
+	// Check if each node (or one of its ancestors) is already contained in the
+	// array.
+	while (--idx > -1) {
+		node = ancestor = nodes[idx];
+
+		// Temporarily remove the node under consideration
+		nodes[idx] = null;
+		replace = true;
+
+		do {
+			if (nodes.indexOf(ancestor) > -1) {
+				replace = false;
+				nodes.splice(idx, 1);
+				break;
+			}
+		} while (ancestor = ancestor.parent)
+
+		// If the node has been found to be unique, re-insert it.
+		if (replace) {
+			nodes[idx] = node;
+		}
+	}
+
+	return nodes;
+};

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "domelementtype": "1"
   },
   "devDependencies": {
-    "htmlparser2": "2.3",
+    "htmlparser2": "~3.3.0",
     "domhandler": "2"
   },
   "author": "Felix Boehm <me@feedic.com>"

--- a/tests/00-runtests.js
+++ b/tests/00-runtests.js
@@ -57,6 +57,8 @@ function runTests(test){
  "./02-dom_utils.js"
 ].map(require).forEach(runTests);
 
+require('./03-remove-subsets')(assert);
+
 //log the results
 (function check(){
 	if(runCount !== 0) return process.nextTick(check);

--- a/tests/03-remove-subsets.js
+++ b/tests/03-remove-subsets.js
@@ -1,0 +1,26 @@
+var htmlparser = require('htmlparser2');
+var removeSubsets = require('..').removeSubsets;
+function makeDom(markup) {
+	var handler = new htmlparser.DomHandler(),
+		parser = new htmlparser.Parser(handler);
+	parser.write(markup);
+	parser.done();
+	return handler.dom;
+}
+
+module.exports = function(assert) {
+	var dom = makeDom("<div><p><span></span></p><p></p></div>")[0];
+	var matches;
+
+	matches = removeSubsets([dom, dom]);
+	assert.equal(matches.length, 1, "Removes identical trees");
+
+	matches = removeSubsets([dom, dom.children[0].children[0]]);
+	assert.equal(matches.length, 1, "Removes subsets found first");
+
+	matches = removeSubsets([dom.children[0], dom]);
+	assert.equal(matches.length, 1, "Removes subsets found last");
+
+	matches = removeSubsets([dom.children[0], dom.children[1]]);
+	assert.equal(matches.length, 2, "Does not remove unique trees");
+};


### PR DESCRIPTION
Hi @fb55,

This functionality is necessary to resolve https://github.com/fb55/CSSselect/issues/12 (and to simplify the solution for https://github.com/MatthewMueller/cheerio/pull/289). It seems odd for it to live in `CSSselect`, so I'm submitting it here.

I'm sure you'll have a lot to say about the code organization, but I think this project could use a little more structure to its source files. I just threw the tests in an arbitrary location, so please let me know how they should be structured, too.

Commit message:

> This allows other libraries to ensure that manually-created collections
> of nodes contain only unique trees.
