### PR TITLE
Catch undefined child

### DIFF
--- a/lib/querying.js
+++ b/lib/querying.js
@@ -83,7 +83,7 @@ function existsOne(test, elems){
 function findAll(test, elems){
 	var result = [];
 	for(var i = 0, j = elems.length; i < j; i++){
-		if(!isTag(elems[i])) continue;
+		if(!elems[i] || !isTag(elems[i])) continue;
 		if(test(elems[i])) result.push(elems[i]);
 
 		if(elems[i].children.length > 0){


### PR DESCRIPTION
Had an error using `cheerio`. This is the best fix that I can think of. Here's the stack trace : 

TypeError: Cannot read property 'type' of undefined
    at module.exports.isTag (my_project\node_modules\cheerio\node_modules\CSSselect\node_modules\domutils\node_modules\domelementtype\index.js:12:14)
    at findAll (my_project\node_modules\cheerio\node_modules\CSSselect\node_modules\domutils\lib\querying.js:91:7)
    at findAll (my_project\node_modules\cheerio\node_modules\CSSselect\node_modules\domutils\lib\querying.js:95:27)
    at findAll (my_project\node_modules\cheerio\node_modules\CSSselect\node_modules\domutils\lib\querying.js:95:27)
    at findAll (my_project\node_modules\cheerio\node_modules\CSSselect\node_modules\domutils\lib\querying.js:95:27)
    at findAll (my_project\node_modules\cheerio\node_modules\CSSselect\node_modules\domutils\lib\querying.js:95:27)
    at Object.findAll (my_project\node_modules\cheerio\node_modules\CSSselect\node_modules\domutils\lib\querying.js:95:27)
    at selectAll (my_project\node_modules\cheerio\node_modules\CSSselect\index.js:25:70)
    at select (my_project\node_modules\cheerio\node_modules\CSSselect\index.js:20:10)
    at CSSselect (my_project\node_modules\cheerio\node_modules\CSSselect\index.js:40:9)
