### PR TITLE
Traverse the tree in depth-first order for findAll.

### DIFF
--- a/lib/querying.js
+++ b/lib/querying.js
@@ -82,18 +82,14 @@ function existsOne(test, elems){
 
 function findAll(test, rootElems){
 	var result = [];
-	var stack = [rootElems];
+	var stack = rootElems.slice();
 	while(stack.length){
-		var elems = stack.pop();
-		for(var i = 0, j = elems.length; i < j; i++){
-			if(!isTag(elems[i])) continue;
-			if(test(elems[i])) result.push(elems[i]);
+		var elem = stack.shift();
+		if(!isTag(elem)) continue;
+		if (elem.children && elem.children.length > 0) {
+			stack.unshift.apply(stack, elem.children);
 		}
-		while(j-- > 0){
-			if(elems[j].children && elems[j].children.length > 0){
-				stack.push(elems[j].children);
-			}
-		}
+		if(test(elem)) result.push(elem);
 	}
 	return result;
 }


### PR DESCRIPTION
The algorithm for findAll was neither breadth-first nor depth-first, but
some hybrid of the two. jQuery and document.querySelectorAll return
results in depth-first order -- the previous change to findAll
broke the code in css-select even though the commit comment said it was
supposed to be in DFS order (this library could use more tests 😅 )