### PR TITLE
Add "sideEffects: false" to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
     "name": "domutils",
     "version": "2.1.0",
     "description": "Utilities for working with htmlparser2's dom",
+    "sideEffects": false,
     "main": "lib/index.js",
     "types": "lib/index.d.ts",
     "files": [


### PR DESCRIPTION
This PR marks `domutils` as free of side effects to allow Webpack to tree shake it if possible. I read through all of the code in this package and didn't spot any side effects, so I think this should be safe.

For more info:
https://webpack.js.org/guides/tree-shaking/
https://developers.google.com/web/fundamentals/performance/optimizing-javascript/tree-shaking