### PR TITLE
fix: children should not be duplicated when called append twice

### DIFF
--- a/src/manipulation.spec.ts
+++ b/src/manipulation.spec.ts
@@ -1,0 +1,35 @@
+import { makeDom } from "./__fixtures__/utils";
+import * as manipulation from "./manipulation";
+import * as assert from "assert";
+import { Element } from "domhandler";
+
+describe("manipulation", () => {
+    describe("append", () => {
+        const { append } = manipulation;
+        test("should not be duplicated when called twice", () => {
+            const dom = makeDom(
+                "<div><p><img/></p><p><img/></p></div>"
+            )[0] as Element;
+            const child = makeDom("<span></span>")[0] as Element;
+            const parents = dom.children as Element[];
+            append(parents[0].children[0], child);
+            append(parents[1].children[0], child);
+            assert.equal(parents[0].children.length, 1);
+            assert.equal(parents[1].children.length, 2);
+        });
+    });
+    describe("appendChild", () => {
+        const { appendChild } = manipulation;
+        test("should not be duplicated when called twice", () => {
+            const dom = makeDom("<div><p></p><p></p></div>")[0] as Element;
+            const child = makeDom("<span></span>")[0] as Element;
+            const parents = dom.children as Element[];
+            appendChild(parents[0], child);
+            appendChild(parents[1], child);
+            assert.equal(parents[0].children.length, 0);
+            assert.equal(parents[1].children.length, 1);
+        });
+    });
+});
+
+//

--- a/src/manipulation.ts
+++ b/src/manipulation.ts
@@ -46,6 +46,8 @@ export function replaceElement(elem: Node, replacement: Node) {
  * @param child The element to be added as a child
  */
 export function appendChild(elem: Element, child: Node) {
+    removeElement(child);
+
     child.parent = elem;
 
     if (elem.children.push(child) !== 1) {
@@ -63,6 +65,8 @@ export function appendChild(elem: Element, child: Node) {
  * @param next The element be added
  */
 export function append(elem: Node, next: Node) {
+    removeElement(next);
+
     const { parent } = elem;
     const currNext = elem.next;
 


### PR DESCRIPTION
This fixes a behavior that does not meet the spec.
https://developer.mozilla.org/en-US/docs/Web/API/Node/appendChild
> appendChild() moves it from its current position to the new position (there is no requirement to remove the node from its parent node before appending it to some other node).