### PR TITLE
fix(traversal): Fix `nextElementSibling` return type

### DIFF
--- a/src/traversal.spec.ts
+++ b/src/traversal.spec.ts
@@ -42,8 +42,8 @@ describe("traversal", () => {
             )[0] as Element;
             const firstNode = dom.children[0];
 
-            const next = nextElementSibling(firstNode) as Element;
-            expect(next.tagName).toBe("p");
+            const next = nextElementSibling(firstNode);
+            expect(next?.tagName).toBe("p");
         });
         it("return null if not found", () => {
             const dom = parseDOM("<div><p></p>test</div>")[0] as Element;
@@ -57,8 +57,8 @@ describe("traversal", () => {
             )[0] as Element;
             const firstNode = dom.children[0];
 
-            const next = nextElementSibling(firstNode) as Element;
-            expect(next.tagName).toBe("script");
+            const next = nextElementSibling(firstNode);
+            expect(next?.tagName).toBe("script");
         });
     });
 });

--- a/src/traversal.ts
+++ b/src/traversal.ts
@@ -96,7 +96,7 @@ export function getName(elem: Element): string {
  * @param elem The element to get the next sibling of.
  * @returns `elem`'s next sibling that is a tag.
  */
-export function nextElementSibling(elem: Node): Node | null {
+export function nextElementSibling(elem: Node): Element | null {
     let { next } = elem;
     while (next !== null && !isTag(next)) ({ next } = next);
     return next;


### PR DESCRIPTION
This commit updates the `nextElementSibling` signature to show that the function always returns elements (not simple nodes). This allows better type inference when using the returned value by encoding this property in the type system.