### PR TITLE
Add support for dc:date fields (RDF)

### DIFF
--- a/src/feeds.ts
+++ b/src/feeds.ts
@@ -167,7 +167,7 @@ function getRssFeed(feedRoot: Element) {
                 addConditionally(entry, "link", "link", children);
                 addConditionally(entry, "description", "description", children);
                 const pubDate =
-                    fetch("pubDate", children) ?? fetch("dc:date", children);
+                    fetch("pubDate", children) || fetch("dc:date", children);
                 if (pubDate) entry.pubDate = new Date(pubDate);
 
                 return entry;

--- a/src/feeds.ts
+++ b/src/feeds.ts
@@ -166,7 +166,8 @@ function getRssFeed(feedRoot: Element) {
                 addConditionally(entry, "title", "title", children);
                 addConditionally(entry, "link", "link", children);
                 addConditionally(entry, "description", "description", children);
-                const pubDate = fetch("pubDate", children);
+                const pubDate =
+                    fetch("pubDate", children) ?? fetch("dc:date", children);
                 if (pubDate) entry.pubDate = new Date(pubDate);
 
                 return entry;


### PR DESCRIPTION
RDF feeds seem to miss the `pubDate` field. This small change uses the `dc:date`if `pubDate` is missing.