### PR TITLE
Export package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,9 +12,11 @@
     "types": "lib/index.d.ts",
     "module": "lib/esm/index.js",
     "exports": {
-        "require": "./lib/index.js",
-        "import": "./lib/esm/index.js",
-        "./package.json": "./package.json"
+        "./package.json": "./package.json",
+        ".": {
+            "require": "./lib/index.js",
+            "import": "./lib/esm/index.js"
+        }
     },
     "files": [
         "lib/**/*"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "module": "lib/esm/index.js",
     "exports": {
         "require": "./lib/index.js",
-        "import": "./lib/esm/index.js"
+        "import": "./lib/esm/index.js",
+        "./package.json": "./package.json"
     },
     "files": [
         "lib/**/*"


### PR DESCRIPTION
Added an export for ./package.json to avoid warnings with React Native and other bundlers.

fixes fb55/domutils#1054