### PR TITLE
docs(readme): Use GitHub Actions CI badge

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# domutils [![Build Status](https://travis-ci.com/fb55/domutils.svg?branch=master)](https://travis-ci.com/fb55/domutils)
+# domutils [![Node.js CI](https://github.com/fb55/domutils/actions/workflows/nodejs-test.yml/badge.svg)](https://github.com/fb55/domutils/actions/workflows/nodejs-test.yml)
 
 Utilities for working with [htmlparser2](https://github.com/fb55/htmlparser2)'s DOM.
 


### PR DESCRIPTION
This was still using Travis CI, which isn't updated anymore.