### PR TITLE
fix: `RangeError: Maximum call stack size exceeded` error at querying.find when children size is too large

### DIFF
--- a/src/querying.spec.ts
+++ b/src/querying.spec.ts
@@ -4,7 +4,7 @@ import { ElementType } from "domelementtype";
 
 describe("querying", () => {
     describe("find", () => {
-        it("should accept too many children without stack overflow", () => {
+        it("should accept too many children without RangeError", () => {
             let html = "<body>";
             for (let i = 0; i < 200000; i++) {
                 html += "<div></div>";

--- a/src/querying.spec.ts
+++ b/src/querying.spec.ts
@@ -1,0 +1,23 @@
+import { parseDocument } from "./__fixtures__/fixture";
+import { find } from "./querying";
+import { ElementType } from "domelementtype";
+
+describe("querying", () => {
+    describe("find", () => {
+        it("should accept too many children without stack overflow", () => {
+            let html = "<body>";
+            for (let i = 0; i < 200000; i++) {
+                html += "<div></div>";
+            }
+            html += "</body>";
+            const nodes = [parseDocument(html)];
+            const resultNodes = find(
+                (elem) => elem.type === ElementType.Tag,
+                nodes,
+                true,
+                Infinity
+            );
+            expect(resultNodes).toHaveLength(200001);
+        });
+    });
+});

--- a/src/querying.ts
+++ b/src/querying.ts
@@ -46,7 +46,7 @@ export function find(
 
         if (recurse && hasChildren(elem) && elem.children.length > 0) {
             const children = find(test, elem.children, recurse, limit);
-            const chunksize = 1024;
+            const chunksize = 50000;
             for (let i = 0; i < children.length; i += chunksize) {
                 result.push(...children.slice(i, i + chunksize));
             }

--- a/src/querying.ts
+++ b/src/querying.ts
@@ -46,7 +46,10 @@ export function find(
 
         if (recurse && hasChildren(elem) && elem.children.length > 0) {
             const children = find(test, elem.children, recurse, limit);
-            result.push(...children);
+            const chunksize = 1024;
+            for (let i = 0; i < children.length; i += chunksize) {
+                result.push(...children.slice(i, i + chunksize));
+            }
             limit -= children.length;
             if (limit <= 0) break;
         }


### PR DESCRIPTION
I encounter the error `RangeError: Maximum call stack size exceeded` at `result.push(...children);` in the `querying.find` method when the children size is too large.
`children.slice` solve the above error.