### PR TITLE
refactor(querying): Reduce memory allocations

### DIFF
--- a/.github/workflows/nodejs-test.yml
+++ b/.github/workflows/nodejs-test.yml
@@ -37,7 +37,6 @@ jobs:
             fail-fast: false
             matrix:
                 node:
-                    - 12
                     - 14
                     - 16
                     - 18

--- a/.github/workflows/nodejs-test.yml
+++ b/.github/workflows/nodejs-test.yml
@@ -9,7 +9,10 @@ on:
 env:
     CI: true
     FORCE_COLOR: 2
-    NODE_COV: 16 # The Node.js version to run coveralls on
+    NODE_COV: "lts/*" # The Node.js version to run coveralls on
+
+permissions:
+    contents: read
 
 jobs:
     lint:
@@ -18,12 +21,15 @@ jobs:
             - uses: actions/checkout@v3
             - uses: actions/setup-node@v3
               with:
-                  node-version: 16
+                  node-version: lts/*
                   cache: npm
             - run: npm ci
             - run: npm run lint
 
     test:
+        permissions:
+            checks: write # for coverallsapp/github-action to create new checks
+            contents: read # for actions/checkout to fetch code
         name: Node ${{ matrix.node }}
         runs-on: ubuntu-latest
 
@@ -31,10 +37,11 @@ jobs:
             fail-fast: false
             matrix:
                 node:
-                    - 10
                     - 12
                     - 14
                     - 16
+                    - 18
+                    - "lts/*"
 
         steps:
             - uses: actions/checkout@v3

--- a/src/__fixtures__/fixture.ts
+++ b/src/__fixtures__/fixture.ts
@@ -1,18 +1,4 @@
-import { Parser, ParserOptions } from "htmlparser2";
-import DomHandler, { Document } from "domhandler";
-
-/**
- * Re-implementation of htmlparser2's `parseDocument` function.
- *
- * @param str String to parse.
- * @param options Optional parser options to use.
- * @returns The parsed document.
- */
-export function parseDocument(str: string, options?: ParserOptions): Document {
-    const handler = new DomHandler();
-    new Parser(handler, options).end(str);
-    return handler.root;
-}
+import { parseDocument } from "htmlparser2";
 
 const markup = Array(21).join(
     "<?xml><tag1 id='asdf'> <script>text</script> <!-- comment --> <tag2> text </tag1>"

--- a/src/feeds.spec.ts
+++ b/src/feeds.spec.ts
@@ -3,7 +3,7 @@
 import { getFeed } from "./feeds";
 import fs from "fs";
 import path from "path";
-import { parseDocument } from "./__fixtures__/fixture";
+import { parseDocument } from "htmlparser2";
 
 const documents = path.join(__dirname, "__fixtures__", "Documents");
 

--- a/src/helpers.spec.ts
+++ b/src/helpers.spec.ts
@@ -1,4 +1,4 @@
-import { parseDocument } from "./__fixtures__/fixture";
+import { parseDocument } from "htmlparser2";
 import { removeSubsets, compareDocumentPosition, uniqueSort } from "./helpers";
 import type { Element, Document } from "domhandler";
 

--- a/src/legacy.spec.ts
+++ b/src/legacy.spec.ts
@@ -32,6 +32,10 @@ describe("legacy", () => {
             expect(getElements({ id: "asdfs" }, fixture, true)).toHaveLength(
                 0
             ));
+        it("returns the node for a ID function", () =>
+            expect(
+                getElements({ id: (id) => id === "asdf" }, fixture, true, 1)
+            ).toEqual([expected.idAsdf]));
         it("returns the nodes with the specified tag name", () =>
             expect(getElements({ tag_name: "tag2" }, fixture, true)).toEqual(
                 expected.tag2
@@ -40,6 +44,18 @@ describe("legacy", () => {
             expect(
                 getElements({ tag_name: "asdfs" }, fixture, true)
             ).toHaveLength(0));
+        it("returns all elements for wildcard tag names", () =>
+            expect(getElements({ tag_name: "*" }, fixture, true)).toHaveLength(
+                60
+            ));
+        it("returns the nodes with the specified tag name function", () =>
+            expect(
+                getElements(
+                    { tag_name: (name) => name === "tag2" },
+                    fixture,
+                    true
+                )
+            ).toEqual(expected.tag2));
         it("returns the nodes with the specified tag type", () =>
             expect(getElements({ tag_type: "script" }, fixture, true)).toEqual(
                 expected.typeScript
@@ -48,6 +64,26 @@ describe("legacy", () => {
             expect(
                 getElements({ tag_type: "video" }, fixture, true)
             ).toHaveLength(0));
+        it("returns the nodes with the specified tag type function", () =>
+            expect(
+                getElements(
+                    { tag_type: (type) => type === "script" },
+                    fixture,
+                    true
+                )
+            ).toEqual(expected.typeScript));
+        it("returns elements for contains", () =>
+            expect(
+                getElements({ tag_contains: "text" }, fixture, true)
+            ).toHaveLength(20));
+        it("returns elements for contains function", () =>
+            expect(
+                getElements(
+                    { tag_contains: (text) => text === "text" },
+                    fixture,
+                    true
+                )
+            ).toHaveLength(20));
     });
 
     describe("getElementById", () => {

--- a/src/querying.spec.ts
+++ b/src/querying.spec.ts
@@ -1,0 +1,125 @@
+import { isTag } from "domhandler";
+import { parseDocument } from "htmlparser2";
+import {
+    existsOne,
+    filter,
+    find,
+    findAll,
+    findOne,
+    findOneChild,
+} from "./querying";
+import { ElementType } from "domelementtype";
+
+describe("querying", () => {
+    const manyNodesWide = parseDocument(
+        `<body>${"<div></div>".repeat(200_000)}Text</body>`
+    ).children;
+
+    describe("find", () => {
+        it("should accept many children without RangeError", () =>
+            expect(
+                find(
+                    (elem) => elem.type === ElementType.Tag,
+                    manyNodesWide,
+                    true,
+                    Infinity
+                )
+            ).toHaveLength(200_001));
+
+        it("should respect limit", () =>
+            expect(
+                find(
+                    (elem) => elem.type === ElementType.Tag,
+                    manyNodesWide,
+                    true,
+                    20
+                )
+            ).toHaveLength(20));
+
+        it("should find text nodes", () =>
+            expect(
+                find(
+                    (elem) => elem.type === ElementType.Text,
+                    manyNodesWide,
+                    true,
+                    Infinity
+                )
+            ).toHaveLength(1));
+    });
+
+    describe("findAll", () => {
+        it("should accept many children without RangeError", () => {
+            expect(
+                findAll((elem) => elem.name === "div", manyNodesWide)
+            ).toHaveLength(200_000);
+        });
+    });
+
+    describe("filter", () => {
+        it("should accept many children without RangeError", () =>
+            expect(
+                filter((elem) => elem.type === ElementType.Tag, manyNodesWide)
+            ).toHaveLength(200_001));
+
+        it("should turn a single node into an array", () =>
+            expect(
+                filter(
+                    (elem) => elem.type === ElementType.Tag,
+                    manyNodesWide[0]
+                )
+            ).toHaveLength(200_001));
+    });
+
+    describe("findOneChild", () => {
+        it("should find elements", () =>
+            expect(
+                findOneChild(
+                    (elem) => isTag(elem) && elem.name === "body",
+                    manyNodesWide
+                )
+            ).toBe(manyNodesWide[0]));
+
+        it("should only query direct children", () =>
+            expect(
+                findOneChild(
+                    (elem) => isTag(elem) && elem.name === "div",
+                    manyNodesWide
+                )
+            ).toBeUndefined());
+    });
+
+    describe("findOne", () => {
+        it("should find elements", () =>
+            expect(
+                findOne((elem) => elem.name === "body", manyNodesWide, true)
+            ).toBe(manyNodesWide[0]));
+
+        it("should find elements in children", () =>
+            expect(
+                findOne((elem) => elem.name === "div", manyNodesWide, true)
+            ).toBe((manyNodesWide[0] as any).children[0]));
+
+        it("should not find elements in children if recurse is false", () =>
+            expect(
+                findOne((elem) => elem.name === "div", manyNodesWide, false)
+            ).toBeNull());
+
+        it("should return `null` if nothing is found", () =>
+            expect(findOne(() => false, manyNodesWide)).toBeNull());
+    });
+
+    describe("existsOne", () => {
+        it("should find elements", () =>
+            expect(
+                existsOne((elem) => elem.name === "body", manyNodesWide)
+            ).toBeTruthy());
+
+        it("should find elements in children", () =>
+            expect(
+                existsOne((elem) => elem.name === "div", manyNodesWide)
+            ).toBeTruthy());
+
+        it("should return `false` if nothing is found", () =>
+            expect(existsOne(() => false, manyNodesWide)).toBeFalsy());
+    });
+});

--- a/src/querying.ts
+++ b/src/querying.ts
@@ -40,25 +40,24 @@ export function find(
     const nodeStack = [nodes];
     /** Stack of the indices within the arrays. */
     const indexStack = [0];
-    /** The index of the array we are currently looking at. */
-    let stackIndex = 0;
 
     for (;;) {
         // First, check if the current array has any more elements to look at.
-        if (indexStack[stackIndex] >= nodeStack[stackIndex].length) {
-            // If not, move up the stack. Note that we don't mutate the stack.
-            stackIndex -= 1;
-
+        if (indexStack[0] >= nodeStack[0].length) {
             // If we have no more arrays to look at, we are done.
-            if (stackIndex < 0) {
+            if (indexStack.length === 1) {
                 return result;
             }
+
+            // Otherwise, remove the current array from the stack.
+            nodeStack.shift();
+            indexStack.shift();
 
             // Loop back to the start to continue with the next array.
             continue;
         }
 
-        const elem = nodeStack[stackIndex][indexStack[stackIndex]++];
+        const elem = nodeStack[0][indexStack[0]++];
 
         if (test(elem)) {
             result.push(elem);
@@ -70,9 +69,8 @@ export function find(
              * Add the children to the stack. We are depth-first, so this is
              * the next array we look at.
              */
-            stackIndex += 1;
-            nodeStack[stackIndex] = elem.children;
-            indexStack[stackIndex] = 0;
+            indexStack.unshift(0);
+            nodeStack.unshift(elem.children);
         }
     }
 }
@@ -159,28 +157,29 @@ export function findAll(
     const result = [];
     const nodeStack = [nodes];
     const indexStack = [0];
-    let stackIndex = 0;
 
     for (;;) {
-        if (indexStack[stackIndex] >= nodeStack[stackIndex].length) {
-            stackIndex -= 1;
-
-            if (stackIndex < 0) {
+        if (indexStack[0] >= nodeStack[0].length) {
+            if (nodeStack.length === 1) {
                 return result;
             }
 
+            // Otherwise, remove the current array from the stack.
+            nodeStack.shift();
+            indexStack.shift();
+
+            // Loop back to the start to continue with the next array.
             continue;
         }
 
-        const elem = nodeStack[stackIndex][indexStack[stackIndex]++];
+        const elem = nodeStack[0][indexStack[0]++];
 
         if (!isTag(elem)) continue;
         if (test(elem)) result.push(elem);
 
         if (elem.children.length > 0) {
-            stackIndex += 1;
-            nodeStack[stackIndex] = elem.children;
-            indexStack[stackIndex] = 0;
+            indexStack.unshift(0);
+            nodeStack.unshift(elem.children);
         }
     }
 }

--- a/src/querying.ts
+++ b/src/querying.ts
@@ -16,8 +16,7 @@ export function filter(
     recurse = true,
     limit = Infinity
 ): AnyNode[] {
-    if (!Array.isArray(node)) node = [node];
-    return find(test, node, recurse, limit);
+    return find(test, Array.isArray(node) ? node : [node], recurse, limit);
 }
 
 /**
@@ -37,22 +36,45 @@ export function find(
     limit: number
 ): AnyNode[] {
     const result: AnyNode[] = [];
+    /** Stack of the arrays we are looking at. */
+    const nodeStack = [nodes];
+    /** Stack of the indices within the arrays. */
+    const indexStack = [0];
+    /** The index of the array we are currently looking at. */
+    let stackIndex = 0;
 
-    for (const elem of nodes) {
+    for (;;) {
+        // First, check if the current array has any more elements to look at.
+        if (indexStack[stackIndex] >= nodeStack[stackIndex].length) {
+            // If not, move up the stack. Note that we don't mutate the stack.
+            stackIndex -= 1;
+
+            // If we have no more arrays to look at, we are done.
+            if (stackIndex < 0) {
+                return result;
+            }
+
+            // Loop back to the start to continue with the next array.
+            continue;
+        }
+
+        const elem = nodeStack[stackIndex][indexStack[stackIndex]++];
+
         if (test(elem)) {
             result.push(elem);
-            if (--limit <= 0) break;
+            if (--limit <= 0) return result;
         }
 
         if (recurse && hasChildren(elem) && elem.children.length > 0) {
-            const children = find(test, elem.children, recurse, limit);
-            result.push(...children);
-            limit -= children.length;
-            if (limit <= 0) break;
+            /*
+             * Add the children to the stack. We are depth-first, so this is
+             * the next array we look at.
+             */
+            stackIndex += 1;
+            nodeStack[stackIndex] = elem.children;
+            indexStack[stackIndex] = 0;
         }
     }
-
-    return result;
 }
 
 /**
@@ -88,13 +110,13 @@ export function findOne(
     let elem = null;
 
     for (let i = 0; i < nodes.length && !elem; i++) {
-        const checked = nodes[i];
-        if (!isTag(checked)) {
+        const node = nodes[i];
+        if (!isTag(node)) {
             continue;
-        } else if (test(checked)) {
-            elem = checked;
-        } else if (recurse && checked.children.length > 0) {
-            elem = findOne(test, checked.children, true);
+        } else if (test(node)) {
+            elem = node;
+        } else if (recurse && node.children.length > 0) {
+            elem = findOne(test, node.children, true);
         }
     }
 
@@ -116,9 +138,7 @@ export function existsOne(
     return nodes.some(
         (checked) =>
             isTag(checked) &&
-            (test(checked) ||
-                (checked.children.length > 0 &&
-                    existsOne(test, checked.children)))
+            (test(checked) || existsOne(test, checked.children))
     );
 }
 
@@ -136,15 +156,31 @@ export function findAll(
     test: (elem: Element) => boolean,
     nodes: AnyNode[]
 ): Element[] {
-    const result: Element[] = [];
-    const stack = nodes.filter(isTag);
-    let elem;
-    while ((elem = stack.shift())) {
-        const children = elem.children?.filter(isTag);
-        if (children && children.length > 0) {
-            stack.unshift(...children);
+    const result = [];
+    const nodeStack = [nodes];
+    const indexStack = [0];
+    let stackIndex = 0;
+
+    for (;;) {
+        if (indexStack[stackIndex] >= nodeStack[stackIndex].length) {
+            stackIndex -= 1;
+
+            if (stackIndex < 0) {
+                return result;
+            }
+
+            continue;
         }
+
+        const elem = nodeStack[stackIndex][indexStack[stackIndex]++];
+
+        if (!isTag(elem)) continue;
         if (test(elem)) result.push(elem);
+
+        if (elem.children.length > 0) {
+            stackIndex += 1;
+            nodeStack[stackIndex] = elem.children;
+            indexStack[stackIndex] = 0;
+        }
     }
-    return result;
 }


### PR DESCRIPTION
This PR introduces a new depth-first search algorithm that needs less memory allocations than before. Also prevents overflows such as #1316.

Fixes #1316
Fixes #1281