### PR TITLE
fix(manipulation): Dereference nodes in `removeChildren`

### DIFF
--- a/src/manipulation.spec.ts
+++ b/src/manipulation.spec.ts
@@ -5,6 +5,7 @@ import {
     prepend,
     prependChild,
     replaceElement,
+    removeElement,
 } from "./manipulation.js";
 import type { Element } from "domhandler";
 
@@ -82,6 +83,47 @@ describe("manipulation", () => {
                   <p>
                     <object />
                     <span />
+                  </p>
+                </div>
+            `);
+        });
+    });
+    describe("removeElement", () => {
+        it("should correctly remove element", () => {
+            const dom = parseDOM(
+                "<div><p><img/><object/></p><p></p></div>"
+            )[0] as Element;
+            const parents = dom.children as Element[];
+
+            const image = parents[0].children[0];
+
+            removeElement(image);
+
+            expect(image.next).toBeNull();
+            expect(image.prev).toBeNull();
+            expect(image.parent).toBeNull();
+
+            expect(dom).toMatchInlineSnapshot(`
+                <div>
+                  <p>
+                    <object />
+                  </p>
+                  <p />
+                </div>
+            `);
+
+            appendChild(parents[1], image);
+
+            expect(parents[0].children).toHaveLength(1);
+            expect(parents[1].children).toHaveLength(1);
+
+            expect(dom).toMatchInlineSnapshot(`
+                <div>
+                  <p>
+                    <object />
+                  </p>
+                  <p>
+                    <img />
                   </p>
                 </div>
             `);

--- a/src/manipulation.ts
+++ b/src/manipulation.ts
@@ -12,8 +12,14 @@ export function removeElement(elem: ChildNode): void {
 
     if (elem.parent) {
         const childs = elem.parent.children;
-        childs.splice(childs.lastIndexOf(elem), 1);
+        const childsIndex = childs.lastIndexOf(elem);
+        if (childsIndex >= 0) {
+            childs.splice(childsIndex, 1);
+        }
     }
+    elem.next = null;
+    elem.prev = null;
+    elem.parent = null;
 }
 
 /**


### PR DESCRIPTION
Supersedes #1271