### PR TITLE
Fix recursion in findOne querying helper. Fixes #1856.

### DIFF
--- a/src/querying.spec.ts
+++ b/src/querying.spec.ts
@@ -14,6 +14,9 @@ describe("querying", () => {
     const manyNodesWide = parseDocument(
         `<body>${"<div></div>".repeat(200_000)}Text</body>`,
     );
+    const someDeepNodes = parseDocument(
+        `<body><div><div></div></div><div><p></p></div></body>`,
+    );
 
     describe("find", () => {
         it("should accept many children without RangeError", () =>
@@ -106,6 +109,15 @@ describe("querying", () => {
                     true,
                 ),
             ).toBe((manyNodesWide.children[0] as Element).children[0]));
+
+        it("should find elements in children in any branch", () =>
+            expect(
+                findOne(
+                    (elem) => elem.name === "p",
+                    someDeepNodes.children,
+                    true,
+                ),
+            ).toBeTruthy());
 
         it("should not find elements in children if recurse is false", () =>
             expect(

--- a/src/querying.ts
+++ b/src/querying.ts
@@ -113,7 +113,7 @@ export function findOne(
         }
         if (recurse && hasChildren(node) && node.children.length > 0) {
             const found = findOne(test, node.children, true);
-            if(found) return found
+            if (found) return found;
         }
     }
 

--- a/src/querying.ts
+++ b/src/querying.ts
@@ -112,7 +112,8 @@ export function findOne(
             return node;
         }
         if (recurse && hasChildren(node) && node.children.length > 0) {
-            return findOne(test, node.children, true);
+            const found = findOne(test, node.children, true);
+            if(found) return found
         }
     }
 


### PR DESCRIPTION
See #1856 for a detailed description of the issue. This fix works by only returning if the search down any particular recursion branch was successful.