### PR TITLE
perf: replace two quadratic scans in helpers with linear ones

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -9,33 +9,81 @@ import { type AnyNode, hasChildren, type ParentNode } from "domhandler";
  * @returns Remaining nodes that aren't contained by other nodes.
  */
 export function removeSubsets(nodes: AnyNode[]): AnyNode[] {
-    let index = nodes.length;
+    const { length } = nodes;
 
     /*
-     * Check if each node (or one of its ancestors) is already contained in the
-     * array.
+     * A lone node is the most common input by far, and the only member it can
+     * be contained by is itself, so walk its ancestors directly rather than
+     * building a set for one entry.
      */
-    while (--index >= 0) {
-        const node = nodes[index];
+    if (length < 2) {
+        if (length === 1) {
+            const node = nodes[0];
+            for (
+                let ancestor = node.parent;
+                ancestor;
+                ancestor = ancestor.parent
+            ) {
+                if (ancestor === node) {
+                    nodes.length = 0;
+                    break;
+                }
+            }
+        }
+        return nodes;
+    }
 
-        /*
-         * Remove the node if it is not unique.
-         * We are going through the array from the end, so we only
-         * have to check nodes that preceed the node under consideration in the array.
-         */
-        if (index > 0 && nodes.lastIndexOf(node, index - 1) >= 0) {
-            nodes.splice(index, 1);
-            continue;
+    /*
+     * Membership is only ever tested against the nodes that were passed in, so
+     * collect them up front. That replaces the `includes` scan run for every
+     * ancestor of every node, which made this O(n^2 * depth), with an O(1)
+     * lookup per ancestor. Each slot is read once and kept, since a getter on
+     * the array would otherwise be invoked twice.
+     */
+    const members = new Set<AnyNode>();
+    const slots: AnyNode[] = [];
+    for (let index = 0; index < length; index++) {
+        const node = nodes[index];
+        slots.push(node);
+        members.add(node);
+    }
+
+    /*
+     * A second set is only needed to drop repeats. If every node was distinct
+     * there are none, so the common case allocates just the one set.
+     */
+    const seen = members.size === length ? null : new Set<AnyNode>();
+    let kept = 0;
+
+    for (let index = 0; index < length; index++) {
+        const node = slots[index];
+
+        /* Keep the first occurrence of each node, as `lastIndexOf` did. */
+        if (seen !== null) {
+            if (seen.has(node)) continue;
+            seen.add(node);
         }
 
+        let contained = false;
         for (let ancestor = node.parent; ancestor; ancestor = ancestor.parent) {
-            if (nodes.includes(ancestor)) {
-                nodes.splice(index, 1);
+            if (members.has(ancestor)) {
+                contained = true;
                 break;
             }
         }
+
+        if (contained) continue;
+
+        /*
+         * Compact the survivors in place, as the splices did. Only write when
+         * the value actually moves, so that an array needing no changes is
+         * never written to -- a frozen array survived the original untouched.
+         */
+        if (kept !== index) nodes[kept] = node;
+        kept++;
     }
 
+    if (kept !== length) nodes.length = kept;
     return nodes;
 }
 /**
@@ -135,9 +183,36 @@ export function compareDocumentPosition(
  * @returns Collection of unique nodes, sorted in document order.
  */
 export function uniqueSort<T extends AnyNode>(nodes: T[]): T[] {
-    nodes = nodes.filter(
-        (node, index, array) => !array.includes(node, index + 1),
-    );
+    /* Nothing to dedupe or sort, and no reason to allocate a Set. */
+    if (nodes.length < 2) {
+        return nodes;
+    }
+
+    /*
+     * Keep the LAST occurrence of each node, as `array.includes(node, index + 1)`
+     * did. That matters for nodes in different documents: they compare equal, and
+     * the sort below is stable, so which duplicate survives decides the output
+     * order. Walking backwards and reversing preserves that, while making the
+     * dedupe O(n) instead of O(n^2).
+     */
+    const seen = new Set<T>();
+    const unique: T[] = [];
+    for (let index = nodes.length - 1; index >= 0; index--) {
+        /*
+         * `filter` skipped holes in a sparse array, so an absent slot must not
+         * become an `undefined` entry in the result.
+         */
+        if (!(index in nodes)) {
+            continue;
+        }
+        const node = nodes[index];
+        if (!seen.has(node)) {
+            seen.add(node);
+            unique.push(node);
+        }
+    }
+    unique.reverse();
+    nodes = unique;
 
     nodes.sort((a, b) => {
         const relative = compareDocumentPosition(a, b);


### PR DESCRIPTION
Two helpers in `src/helpers.ts` each run an O(n) array scan inside a loop over that same array, which makes them quadratic. Both are on paths that `css-select` and cheerio call for every selector match, so the cost shows up on ordinary traversal work.

### `removeSubsets`

For every ancestor of every node it called `nodes.includes(ancestor)`, then spliced matches out. That is O(n^2 * depth) comparisons, and each splice also reindexes the array, so the two costs compound.

Membership is only ever tested against the nodes that were passed in, so they now go into a `Set` once and each ancestor check is O(1). Survivors are compacted in place.

### `uniqueSort`

The dedupe was `nodes.filter((node, index, array) => !array.includes(node, index + 1))`, which is O(n^2).

The obvious `new Set(nodes)` is not equivalent, and this is the part I want to flag clearly: a `Set` keeps the **first** occurrence, while `includes(node, index + 1)` keeps the **last**. For nodes in different documents `compareDocumentPosition` returns `DISCONNECTED`, the comparator returns 0, and the sort is stable, so which duplicate survives decides the output order. Walking backwards and reversing keeps the last occurrence.

I measured that difference rather than assuming it: over 20,000 randomized cross-document multisets, a first-occurrence `Set` differs from the current behaviour on 7,079 of them. The implementation here differs on 0.

## Numbers

Node v24.18.0, min and median of 21 ABBA-interleaved rounds against a separately built copy of `master`, on a flat sibling result set of the shape `selectAll` produces. The A/A control (two byte-identical trees) ran 0.994x to 1.008x, so anything past a few percent is real:

| nodes | master (median) | this branch (median) | speedup (median) | speedup (min) |
|------:|----------------:|---------------------:|-----------------:|--------------:|
|  1000 |         1.38 ms |              0.05 ms |            27.3x |         29.4x |
|  2000 |         5.69 ms |              0.10 ms |            55.2x |         63.0x |
|  4000 |        22.03 ms |              0.21 ms |           106.2x |        124.6x |

The speedup grows with n because the quadratic term is gone, not because of a better constant factor.

Duplicate-free input gains much less, roughly 1.0x to 1.2x, because `includes` short-circuits on its first comparison there and the sort dominates. The win is for the duplicate-heavy, many-sibling collections that traversal APIs produce, which is what `.parents()`, `.add()` and `.siblings()` hand these helpers.

## Behaviour

I kept every contract the originals had, and checked each one:

- `uniqueSort` still skips holes in a sparse array, as `filter` did. An absent slot must not become an `undefined` entry, and an earlier draft of this patch got that wrong.
- `removeSubsets` still keeps the first occurrence of each node, as `lastIndexOf(node, index - 1)` did.
- Both still mutate the caller's array in place and return that same array. Callers rely on both, so I asserted identity, not just contents.
- Fewer than two nodes skips the `Set` entirely in both helpers. Without that guard `uniqueSort([])` was about 2x slower than before, since it paid for a `Set` it could never use. It is now about 3x faster than `master` on that input.
- Each slot is read exactly once into a local list, matching the current code.
- Survivors are only written when a value actually moves, so an array needing no changes is never written to.

Differential testing against `master`:

- 30,000 randomized multisets drawn from three separately parsed documents, mixing nested nodes, duplicates and cross-document nodes, compared element by element. 0 mismatches.
- A further 20,000 cross-document multisets compared specifically against the original last-occurrence dedupe. 0 mismatches.
- Explicit probes for sparse arrays, empty input, in-place mutation, returned-array identity, and a slot getter that raises on a second read.

## One known difference, and why I left it

Read order changes if a property getter mutates the tree or the array during the call. `removeSubsets` now visits nodes front to back rather than back to front, and `uniqueSort` checks sparse slots in the other direction. With a getter on `a.parent` that sets `b.parent = a`:

```
master:      ["a", "b"]
this branch: ["a"]
```

A getter on index 0 of a sparse array that materialises index 1 shows the same shape of difference. Neither is observable for ordinary input.

I tried twice to preserve the original visit order and both attempts were worse than the problem. One used a `Map` of last-seen index, which broke last-occurrence semantics, because a `Map` iterates in insertion order and puts a repeated node at its first position rather than its last. The other turned a wrong result into a thrown `TypeError`. So I stopped and am disclosing it instead.

My read is that a getter which mutates the tree mid-call is not a supported pattern for these helpers, but it is a real difference and whether it matters is your call.

## Checks

`npm test` passes with 79 tests and exit code 0, which also runs eslint, `tsc --noEmit` and biome. `npm run lint` is clean separately.

One note on motivation: the first-versus-last duplicate detail above is not hypothetical. I originally tried fixing this in cheerio with a `Set` and it changed `.parents()` output order on multi-root selections, which is why this belongs here in `uniqueSort` and why the direction matters.
