### PR TITLE
fix(helpers): correct sibling lookup in compareDocumentPosition for leaf nodes

### DIFF
--- a/src/helpers.spec.ts
+++ b/src/helpers.spec.ts
@@ -70,6 +70,17 @@ describe("helpers", () => {
                 ),
             ).toBe(10);
         });
+
+        it("reports the correct order when a sibling is a comment", () => {
+            const dom = parseDocument("<div><p></p><!--c--><a></a></div>")
+                .children[0] as Element;
+            const [p, comment, a] = dom.children;
+
+            expect(compareDocumentPosition(p, comment)).toBe(2);
+            expect(compareDocumentPosition(comment, p)).toBe(4);
+            expect(compareDocumentPosition(comment, a)).toBe(2);
+            expect(compareDocumentPosition(a, comment)).toBe(4);
+        });
     });
 
     describe("uniqueSort", () => {

--- a/src/helpers.spec.ts
+++ b/src/helpers.spec.ts
@@ -2,128 +2,134 @@ import type { Document, Element } from "domhandler";
 import { parseDocument } from "htmlparser2";
 import { beforeEach, describe, expect, it } from "vitest";
 import {
-  compareDocumentPosition,
-  removeSubsets,
-  uniqueSort,
+    compareDocumentPosition,
+    removeSubsets,
+    uniqueSort,
 } from "./helpers.js";
 
 describe("helpers", () => {
-  describe("removeSubsets", () => {
-    const dom = parseDocument("<div><p><span></span></p><p></p></div>")
-      .children[0] as Element;
+    describe("removeSubsets", () => {
+        const dom = parseDocument("<div><p><span></span></p><p></p></div>")
+            .children[0] as Element;
 
-    it("removes identical trees", () =>
-      expect(removeSubsets([dom, dom])).toHaveLength(1));
+        it("removes identical trees", () =>
+            expect(removeSubsets([dom, dom])).toHaveLength(1));
 
-    it("Removes subsets found first", () => {
-      const firstChild = dom.children[0] as Element;
-      const matches = removeSubsets([dom, firstChild.children[0]]);
-      expect(matches).toHaveLength(1);
+        it("Removes subsets found first", () => {
+            const firstChild = dom.children[0] as Element;
+            const matches = removeSubsets([dom, firstChild.children[0]]);
+            expect(matches).toHaveLength(1);
+        });
+
+        it("Removes subsets found last", () =>
+            expect(removeSubsets([dom.children[0], dom])).toHaveLength(1));
+
+        it("Does not remove unique trees", () =>
+            expect(
+                removeSubsets([dom.children[0], dom.children[1]]),
+            ).toHaveLength(2));
     });
 
-    it("Removes subsets found last", () =>
-      expect(removeSubsets([dom.children[0], dom])).toHaveLength(1));
+    describe("compareDocumentPosition", () => {
+        const markup = "<div><p><span></span></p><a></a></div>";
+        const dom = parseDocument(markup).children[0] as Element;
+        const p = dom.children[0] as Element;
+        const span = p.children[0];
+        const a = dom.children[1];
 
-    it("Does not remove unique trees", () =>
-      expect(removeSubsets([dom.children[0], dom.children[1]])).toHaveLength(
-        2,
-      ));
-  });
+        it("reports when the first node occurs before the second indirectly", () =>
+            expect(compareDocumentPosition(span, a)).toBe(2));
 
-  describe("compareDocumentPosition", () => {
-    const markup = "<div><p><span></span></p><a></a></div>";
-    const dom = parseDocument(markup).children[0] as Element;
-    const p = dom.children[0] as Element;
-    const span = p.children[0];
-    const a = dom.children[1];
+        it("reports when the first node contains the second", () =>
+            expect(compareDocumentPosition(p, span)).toBe(10));
 
-    it("reports when the first node occurs before the second indirectly", () =>
-      expect(compareDocumentPosition(span, a)).toBe(2));
+        it("reports when the first node occurs after the second indirectly", () =>
+            expect(compareDocumentPosition(a, span)).toBe(4));
 
-    it("reports when the first node contains the second", () =>
-      expect(compareDocumentPosition(p, span)).toBe(10));
+        it("reports when the first node is contained by the second", () =>
+            expect(compareDocumentPosition(span, p)).toBe(20));
 
-    it("reports when the first node occurs after the second indirectly", () =>
-      expect(compareDocumentPosition(a, span)).toBe(4));
+        it("reports when the nodes belong to separate documents", () => {
+            const otherDom = parseDocument(markup).children[0] as Element;
+            const other = (otherDom.children[0] as Element).children[0];
 
-    it("reports when the first node is contained by the second", () =>
-      expect(compareDocumentPosition(span, p)).toBe(20));
+            expect(compareDocumentPosition(span, other)).toBe(1);
+        });
 
-    it("reports when the nodes belong to separate documents", () => {
-      const otherDom = parseDocument(markup).children[0] as Element;
-      const other = (otherDom.children[0] as Element).children[0];
+        it("reports when the nodes are identical", () =>
+            expect(compareDocumentPosition(span, span)).toBe(0));
 
-      expect(compareDocumentPosition(span, other)).toBe(1);
+        it("does not end up in infinite loop (#109)", () => {
+            const dom = parseDocument("<div><span>1</span><span>2</span></div>")
+                .children[0] as Element;
+
+            expect(
+                compareDocumentPosition(
+                    dom.children[0],
+                    (dom.children[0] as Element).children[0],
+                ),
+            ).toBe(10);
+        });
+
+        it("reports the correct order when a sibling is a comment", () => {
+            const dom = parseDocument("<div><p></p><!--c--><a></a></div>")
+                .children[0] as Element;
+            const [p, comment, a] = dom.children;
+
+            expect(compareDocumentPosition(p, comment)).toBe(2);
+            expect(compareDocumentPosition(comment, p)).toBe(4);
+            expect(compareDocumentPosition(comment, a)).toBe(2);
+            expect(compareDocumentPosition(a, comment)).toBe(4);
+        });
     });
 
-    it("reports when the nodes are identical", () =>
-      expect(compareDocumentPosition(span, span)).toBe(0));
+    describe("uniqueSort", () => {
+        let root: Document;
+        let dom: Element;
+        let p: Element;
+        let span: Element;
+        let a: Element;
 
-    it("does not end up in infinite loop (#109)", () => {
-      const dom = parseDocument("<div><span>1</span><span>2</span></div>")
-        .children[0] as Element;
+        beforeEach(() => {
+            root = parseDocument("<div><p><span></span></p><a></a></div>");
+            [dom] = root.children as Element[];
+            [p, a] = dom.children as Element[];
+            [span] = p.children as Element[];
+        });
 
-      expect(
-        compareDocumentPosition(
-          dom.children[0],
-          (dom.children[0] as Element).children[0],
-        ),
-      ).toBe(10);
+        it("leaves unique elements untouched", () =>
+            expect(uniqueSort([p, a])).toStrictEqual([p, a]));
+
+        it("removes duplicate elements", () =>
+            expect(uniqueSort([p, a, p])).toStrictEqual([p, a]));
+
+        it("sorts a comment sibling into document order", () => {
+            const withComment = parseDocument(
+                "<div><p></p><!--c--><a></a></div>",
+            ).children[0] as Element;
+            const [firstP, comment, lastA] = withComment.children;
+
+            expect(uniqueSort([lastA, comment, firstP])).toStrictEqual([
+                firstP,
+                comment,
+                lastA,
+            ]);
+        });
+
+        it("sorts nodes in document order", () =>
+            expect(uniqueSort([a, dom, span, p])).toStrictEqual([
+                dom,
+                p,
+                span,
+                a,
+            ]));
+        it("puts the document node in the right spot", () =>
+            expect(uniqueSort([a, dom, span, root, p])).toStrictEqual([
+                root,
+                dom,
+                p,
+                span,
+                a,
+            ]));
     });
-
-    it("reports the correct order when a sibling is a comment", () => {
-      const dom = parseDocument("<div><p></p><!--c--><a></a></div>")
-        .children[0] as Element;
-      const [p, comment, a] = dom.children;
-
-      expect(compareDocumentPosition(p, comment)).toBe(2);
-      expect(compareDocumentPosition(comment, p)).toBe(4);
-      expect(compareDocumentPosition(comment, a)).toBe(2);
-      expect(compareDocumentPosition(a, comment)).toBe(4);
-    });
-  });
-
-  describe("uniqueSort", () => {
-    let root: Document;
-    let dom: Element;
-    let p: Element;
-    let span: Element;
-    let a: Element;
-
-    beforeEach(() => {
-      root = parseDocument("<div><p><span></span></p><a></a></div>");
-      [dom] = root.children as Element[];
-      [p, a] = dom.children as Element[];
-      [span] = p.children as Element[];
-    });
-
-    it("leaves unique elements untouched", () =>
-      expect(uniqueSort([p, a])).toStrictEqual([p, a]));
-
-    it("removes duplicate elements", () =>
-      expect(uniqueSort([p, a, p])).toStrictEqual([p, a]));
-
-    it("sorts a comment sibling into document order", () => {
-      const withComment = parseDocument("<div><p></p><!--c--><a></a></div>")
-        .children[0] as Element;
-      const [firstP, comment, lastA] = withComment.children;
-
-      expect(uniqueSort([lastA, comment, firstP])).toStrictEqual([
-        firstP,
-        comment,
-        lastA,
-      ]);
-    });
-
-    it("sorts nodes in document order", () =>
-      expect(uniqueSort([a, dom, span, p])).toStrictEqual([dom, p, span, a]));
-    it("puts the document node in the right spot", () =>
-      expect(uniqueSort([a, dom, span, root, p])).toStrictEqual([
-        root,
-        dom,
-        p,
-        span,
-        a,
-      ]));
-  });
 });

--- a/src/helpers.spec.ts
+++ b/src/helpers.spec.ts
@@ -2,134 +2,128 @@ import type { Document, Element } from "domhandler";
 import { parseDocument } from "htmlparser2";
 import { beforeEach, describe, expect, it } from "vitest";
 import {
-    compareDocumentPosition,
-    removeSubsets,
-    uniqueSort,
+  compareDocumentPosition,
+  removeSubsets,
+  uniqueSort,
 } from "./helpers.js";
 
 describe("helpers", () => {
-    describe("removeSubsets", () => {
-        const dom = parseDocument("<div><p><span></span></p><p></p></div>")
-            .children[0] as Element;
+  describe("removeSubsets", () => {
+    const dom = parseDocument("<div><p><span></span></p><p></p></div>")
+      .children[0] as Element;
 
-        it("removes identical trees", () =>
-            expect(removeSubsets([dom, dom])).toHaveLength(1));
+    it("removes identical trees", () =>
+      expect(removeSubsets([dom, dom])).toHaveLength(1));
 
-        it("Removes subsets found first", () => {
-            const firstChild = dom.children[0] as Element;
-            const matches = removeSubsets([dom, firstChild.children[0]]);
-            expect(matches).toHaveLength(1);
-        });
-
-        it("Removes subsets found last", () =>
-            expect(removeSubsets([dom.children[0], dom])).toHaveLength(1));
-
-        it("Does not remove unique trees", () =>
-            expect(
-                removeSubsets([dom.children[0], dom.children[1]]),
-            ).toHaveLength(2));
+    it("Removes subsets found first", () => {
+      const firstChild = dom.children[0] as Element;
+      const matches = removeSubsets([dom, firstChild.children[0]]);
+      expect(matches).toHaveLength(1);
     });
 
-    describe("compareDocumentPosition", () => {
-        const markup = "<div><p><span></span></p><a></a></div>";
-        const dom = parseDocument(markup).children[0] as Element;
-        const p = dom.children[0] as Element;
-        const span = p.children[0];
-        const a = dom.children[1];
+    it("Removes subsets found last", () =>
+      expect(removeSubsets([dom.children[0], dom])).toHaveLength(1));
 
-        it("reports when the first node occurs before the second indirectly", () =>
-            expect(compareDocumentPosition(span, a)).toBe(2));
+    it("Does not remove unique trees", () =>
+      expect(removeSubsets([dom.children[0], dom.children[1]])).toHaveLength(
+        2,
+      ));
+  });
 
-        it("reports when the first node contains the second", () =>
-            expect(compareDocumentPosition(p, span)).toBe(10));
+  describe("compareDocumentPosition", () => {
+    const markup = "<div><p><span></span></p><a></a></div>";
+    const dom = parseDocument(markup).children[0] as Element;
+    const p = dom.children[0] as Element;
+    const span = p.children[0];
+    const a = dom.children[1];
 
-        it("reports when the first node occurs after the second indirectly", () =>
-            expect(compareDocumentPosition(a, span)).toBe(4));
+    it("reports when the first node occurs before the second indirectly", () =>
+      expect(compareDocumentPosition(span, a)).toBe(2));
 
-        it("reports when the first node is contained by the second", () =>
-            expect(compareDocumentPosition(span, p)).toBe(20));
+    it("reports when the first node contains the second", () =>
+      expect(compareDocumentPosition(p, span)).toBe(10));
 
-        it("reports when the nodes belong to separate documents", () => {
-            const otherDom = parseDocument(markup).children[0] as Element;
-            const other = (otherDom.children[0] as Element).children[0];
+    it("reports when the first node occurs after the second indirectly", () =>
+      expect(compareDocumentPosition(a, span)).toBe(4));
 
-            expect(compareDocumentPosition(span, other)).toBe(1);
-        });
+    it("reports when the first node is contained by the second", () =>
+      expect(compareDocumentPosition(span, p)).toBe(20));
 
-        it("reports when the nodes are identical", () =>
-            expect(compareDocumentPosition(span, span)).toBe(0));
+    it("reports when the nodes belong to separate documents", () => {
+      const otherDom = parseDocument(markup).children[0] as Element;
+      const other = (otherDom.children[0] as Element).children[0];
 
-        it("does not end up in infinite loop (#109)", () => {
-            const dom = parseDocument("<div><span>1</span><span>2</span></div>")
-                .children[0] as Element;
-
-            expect(
-                compareDocumentPosition(
-                    dom.children[0],
-                    (dom.children[0] as Element).children[0],
-                ),
-            ).toBe(10);
-        });
-
-        it("reports the correct order when a sibling is a comment", () => {
-            const dom = parseDocument("<div><p></p><!--c--><a></a></div>")
-                .children[0] as Element;
-            const [p, comment, a] = dom.children;
-
-            expect(compareDocumentPosition(p, comment)).toBe(2);
-            expect(compareDocumentPosition(comment, p)).toBe(4);
-            expect(compareDocumentPosition(comment, a)).toBe(2);
-            expect(compareDocumentPosition(a, comment)).toBe(4);
-        });
+      expect(compareDocumentPosition(span, other)).toBe(1);
     });
 
-    describe("uniqueSort", () => {
-        let root: Document;
-        let dom: Element;
-        let p: Element;
-        let span: Element;
-        let a: Element;
+    it("reports when the nodes are identical", () =>
+      expect(compareDocumentPosition(span, span)).toBe(0));
 
-        beforeEach(() => {
-            root = parseDocument("<div><p><span></span></p><a></a></div>");
-            [dom] = root.children as Element[];
-            [p, a] = dom.children as Element[];
-            [span] = p.children as Element[];
-        });
+    it("does not end up in infinite loop (#109)", () => {
+      const dom = parseDocument("<div><span>1</span><span>2</span></div>")
+        .children[0] as Element;
 
-        it("leaves unique elements untouched", () =>
-            expect(uniqueSort([p, a])).toStrictEqual([p, a]));
-
-        it("removes duplicate elements", () =>
-            expect(uniqueSort([p, a, p])).toStrictEqual([p, a]));
-
-        it("sorts a comment sibling into document order", () => {
-            const withComment = parseDocument(
-                "<div><p></p><!--c--><a></a></div>",
-            ).children[0] as Element;
-            const [firstP, comment, lastA] = withComment.children;
-
-            expect(uniqueSort([lastA, comment, firstP])).toStrictEqual([
-                firstP,
-                comment,
-                lastA,
-            ]);
-        });
-
-        it("sorts nodes in document order", () =>
-            expect(uniqueSort([a, dom, span, p])).toStrictEqual([
-                dom,
-                p,
-                span,
-                a,
-            ]));
-        it("puts the document node in the right spot", () =>
-            expect(uniqueSort([a, dom, span, root, p])).toStrictEqual([
-                root,
-                dom,
-                p,
-                span,
-                a,
-            ]));
+      expect(
+        compareDocumentPosition(
+          dom.children[0],
+          (dom.children[0] as Element).children[0],
+        ),
+      ).toBe(10);
     });
+
+    it("reports the correct order when a sibling is a comment", () => {
+      const dom = parseDocument("<div><p></p><!--c--><a></a></div>")
+        .children[0] as Element;
+      const [p, comment, a] = dom.children;
+
+      expect(compareDocumentPosition(p, comment)).toBe(2);
+      expect(compareDocumentPosition(comment, p)).toBe(4);
+      expect(compareDocumentPosition(comment, a)).toBe(2);
+      expect(compareDocumentPosition(a, comment)).toBe(4);
+    });
+  });
+
+  describe("uniqueSort", () => {
+    let root: Document;
+    let dom: Element;
+    let p: Element;
+    let span: Element;
+    let a: Element;
+
+    beforeEach(() => {
+      root = parseDocument("<div><p><span></span></p><a></a></div>");
+      [dom] = root.children as Element[];
+      [p, a] = dom.children as Element[];
+      [span] = p.children as Element[];
+    });
+
+    it("leaves unique elements untouched", () =>
+      expect(uniqueSort([p, a])).toStrictEqual([p, a]));
+
+    it("removes duplicate elements", () =>
+      expect(uniqueSort([p, a, p])).toStrictEqual([p, a]));
+
+    it("sorts a comment sibling into document order", () => {
+      const withComment = parseDocument("<div><p></p><!--c--><a></a></div>")
+        .children[0] as Element;
+      const [firstP, comment, lastA] = withComment.children;
+
+      expect(uniqueSort([lastA, comment, firstP])).toStrictEqual([
+        firstP,
+        comment,
+        lastA,
+      ]);
+    });
+
+    it("sorts nodes in document order", () =>
+      expect(uniqueSort([a, dom, span, p])).toStrictEqual([dom, p, span, a]));
+    it("puts the document node in the right spot", () =>
+      expect(uniqueSort([a, dom, span, root, p])).toStrictEqual([
+        root,
+        dom,
+        p,
+        span,
+        a,
+      ]));
+  });
 });

--- a/src/helpers.spec.ts
+++ b/src/helpers.spec.ts
@@ -103,6 +103,19 @@ describe("helpers", () => {
         it("removes duplicate elements", () =>
             expect(uniqueSort([p, a, p])).toStrictEqual([p, a]));
 
+        it("sorts a comment sibling into document order", () => {
+            const withComment = parseDocument(
+                "<div><p></p><!--c--><a></a></div>",
+            ).children[0] as Element;
+            const [firstP, comment, lastA] = withComment.children;
+
+            expect(uniqueSort([lastA, comment, firstP])).toStrictEqual([
+                firstP,
+                comment,
+                lastA,
+            ]);
+        });
+
         it("sorts nodes in document order", () =>
             expect(uniqueSort([a, dom, span, p])).toStrictEqual([
                 dom,

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -110,8 +110,8 @@ export function compareDocumentPosition(
 
     const sharedParent = aParents[index - 1];
     const siblings: AnyNode[] = sharedParent.children;
-    const aSibling = aParents[index];
-    const bSibling = bParents[index];
+    const aSibling = index < aParents.length ? aParents[index] : nodeA;
+    const bSibling = index < bParents.length ? bParents[index] : nodeB;
 
     if (siblings.indexOf(aSibling) > siblings.indexOf(bSibling)) {
         if (sharedParent === nodeB) {


### PR DESCRIPTION
`compareDocumentPosition` builds each node's ancestor chain with `hasChildren(node) ? node : node.parent`, so a node that can't have children (a text, comment or processing-instruction node) is represented by its parent, not itself. When such a leaf node is compared against an element that is its sibling, the two chains differ in length by one, and the sibling lookup `aParents[index]` / `bParents[index]` reads past the end of the shorter chain and returns `undefined`. `siblings.indexOf(undefined)` is `-1`, so the order check silently produces the opposite result.

For `<div><p></p><!--c--><a></a></div>`, `compareDocumentPosition(p, comment)` returned `FOLLOWING` instead of `PRECEDING`, and `uniqueSort` (built on this) sorts such nodes out of document order. When a chain is exhausted, the node itself is the sibling to compare; this uses it. Verified against `jsdom`'s document ordering.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/fb55/domutils/pull/2329?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected document position comparisons involving HTML comment nodes and sibling elements.
  * Improved document-order sorting when HTML comments are present.
  * Ensured accurate results when comparing comments with nearby paragraph and anchor elements.

* **Tests**
  * Added coverage for sibling ordering and document-order sorting involving HTML comments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->